### PR TITLE
Fix Potential ChestGUI Bug

### DIFF
--- a/src/main/java/games/negative/alumina/menu/ChestMenu.java
+++ b/src/main/java/games/negative/alumina/menu/ChestMenu.java
@@ -84,7 +84,9 @@ public abstract class ChestMenu implements AluminaMenu {
      */
     @Override
     public void setItem(int slot, @NotNull ItemStack item, @Nullable String functionKey) {
-        items.remove(slot);
+        MenuItem removed = items.remove(slot);
+        if (removed != null)
+            byKey.remove(removed.key());
 
         applyFunction(item, functionKey);
 
@@ -140,6 +142,11 @@ public abstract class ChestMenu implements AluminaMenu {
     @Override
     public void clearSlot(int slot) {
         inventory.clear(slot);
+
+        // Ensure to remove from the map.
+        MenuItem removed = items.remove(slot);
+        if (removed != null)
+            byKey.remove(removed.key());
     }
 
     /**


### PR DESCRIPTION
Fixed a potential bug where if the menu item was removed from the GUI, it would not remove from the function map (see `clearSlot`), and also prevent a overlap where on `setItem` where it would not remove from `byKey`