### PR TITLE
Add advanced tab completion system

### DIFF
--- a/src/main/java/games/negative/alumina/command/Command.java
+++ b/src/main/java/games/negative/alumina/command/Command.java
@@ -26,6 +26,9 @@
 package games.negative.alumina.command;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 /**
  * This interface is used to mark a class as a command.
@@ -43,4 +46,15 @@ public interface Command {
      * @param context The context of the command.
      */
     void execute(@NotNull Context context);
+
+    /**
+     * This method is called when the command is tab completed.
+     * @param context The context of the command.
+     * @return a list of possible completions for the command.
+     * @apiNote This method is optional, override to add proper functionality.
+     */
+    @Nullable
+    default List<String> onTabComplete(@NotNull TabContext context) {
+        return null;
+    }
 }

--- a/src/main/java/games/negative/alumina/command/TabContext.java
+++ b/src/main/java/games/negative/alumina/command/TabContext.java
@@ -1,0 +1,44 @@
+package games.negative.alumina.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Optional;
+
+/**
+ * Represents the context of a tab completion.
+ * @param args The arguments of the command.
+ * @param sender The sender of the command.
+ */
+public record TabContext(@NotNull CommandSender sender, @NotNull String[] args) {
+
+    /**
+     * Returns the player who executed the command.
+     * @return the player who executed the command.
+     */
+    public Optional<Player> player() {
+        return sender() instanceof Player ? Optional.of((Player) sender()) : Optional.empty();
+    }
+
+    /**
+     * Returns the argument at the specified index.
+     * @param index The index of the argument.
+     * @return the argument at the specified index.
+     */
+    @NotNull
+    public Optional<String> argument(int index) {
+        return (index >= args.length ? Optional.empty() : Optional.of(args[index]));
+    }
+
+    /**
+     * Returns the current argument used in the command.
+     * @return the current argument.
+     */
+    @NotNull
+    public String current() {
+        return argument(args.length - 1).orElseThrow(() -> new IllegalStateException("No current argument"));
+    }
+
+}

--- a/src/main/java/games/negative/alumina/command/builder/CommandBuilder.java
+++ b/src/main/java/games/negative/alumina/command/builder/CommandBuilder.java
@@ -62,6 +62,7 @@ public class CommandBuilder {
     private String[] params;
 
     private String[] shortcuts;
+    private boolean smartTabComplete;
 
     private final List<CommandBuilder> subCommands;
 
@@ -75,6 +76,7 @@ public class CommandBuilder {
         this.aliases = Lists.newArrayList();
         this.usage = "";
         this.description = "";
+        this.smartTabComplete = false;
     }
 
     /**
@@ -220,6 +222,26 @@ public class CommandBuilder {
     public CommandBuilder subcommands(CommandBuilder... commands) {
         Preconditions.checkNotNull(commands, "Command subcommands cannot be null.");
         subCommands.addAll(Arrays.asList(commands));
+        return this;
+    }
+
+    /**
+     * Set the state of the command to "smart tab complete", meaning
+     * the command will automatically tab complete the sub commands.
+     * @return The command builder.
+     */
+    public CommandBuilder smartTabComplete() {
+        return smartTabComplete(true);
+    }
+
+    /**
+     * Set the state of the command to "smart tab complete", meaning
+     * the command will automatically tab complete the sub commands.
+     * @param value The value of the smart tab complete.
+     * @return The command builder.
+     */
+    public CommandBuilder smartTabComplete(boolean value) {
+        this.smartTabComplete = value;
         return this;
     }
 


### PR DESCRIPTION
This PR finally adds the long-awaited tab completion system. You can customize the tab completion (on the main command, not subcommands), and also allow for a system called "smart tab completer", which will automatically make a tab completion system for subcommands!

All it requires is enabling the smart tab complete in the command builder (of the main command, not subcommand.)!