### PR TITLE
Remove annotations from api

### DIFF
--- a/src/main/java/games/negative/alumina/AluminaPlugin.java
+++ b/src/main/java/games/negative/alumina/AluminaPlugin.java
@@ -25,6 +25,7 @@
 
 package games.negative.alumina;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import games.negative.alumina.command.builder.CommandBuilder;
 import games.negative.alumina.command.structure.AluminaCommand;
@@ -36,15 +37,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.Server;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandMap;
-import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
@@ -80,7 +76,9 @@ public abstract class AluminaPlugin extends JavaPlugin {
      *
      * @param builder The builder used to create the command.
      */
-    public void registerCommand(@NotNull CommandBuilder builder) {
+    public void registerCommand(final CommandBuilder builder) {
+        Preconditions.checkNotNull(builder, "Command builder cannot be null!");
+
         CommandMap commandMap = initCommandMap();
         if (commandMap == null) return;
 
@@ -117,8 +115,9 @@ public abstract class AluminaPlugin extends JavaPlugin {
      * @param parent The parent command.
      * @return A list of all subcommands.
      */
-    @NotNull
-    private List<AluminaCommand> getRecursiveSubCommand(@NotNull AluminaCommand parent) {
+    private List<AluminaCommand> getRecursiveSubCommand(final AluminaCommand parent) {
+        Preconditions.checkNotNull(parent, "Parent command cannot be null!");
+
         // Recursively get all subcommands of all subcommands.
         List<AluminaCommand> list = Lists.newArrayList(parent.getSubCommands());
 
@@ -139,7 +138,11 @@ public abstract class AluminaPlugin extends JavaPlugin {
      * @param existing The existing command.
      * @param commandMap The command map.
      */
-    private void cleanse(@NotNull String name, @NotNull Command existing, @NotNull CommandMap commandMap) {
+    private void cleanse(final String name, final Command existing, final CommandMap commandMap) {
+        Preconditions.checkNotNull(name, "Command name cannot be null!");
+        Preconditions.checkNotNull(existing, "Existing command cannot be null!");
+        Preconditions.checkNotNull(commandMap, "Command map cannot be null!");
+
         Map<String, Command> map;
         try {
             map = (Map<String, Command>) commandMap.getClass().getDeclaredMethod("getKnownCommands").invoke(commandMap);
@@ -157,7 +160,6 @@ public abstract class AluminaPlugin extends JavaPlugin {
      * This method is used to initialize the command map.
      * @return The command map.
      */
-    @Nullable
     private CommandMap initCommandMap() {
         Server server = Bukkit.getServer();
         Field field;
@@ -181,7 +183,10 @@ public abstract class AluminaPlugin extends JavaPlugin {
         return commandMap;
     }
     
-    public void registerListeners(@NotNull Listener... listeners) {
+    public void registerListeners(final Listener... listeners) {
+        Preconditions.checkNotNull(listeners, "Listeners cannot be null!");
+        Preconditions.checkArgument(listeners.length > 0, "Listeners cannot be empty!");
+
         PluginManager manager = Bukkit.getPluginManager();
 
         for (Listener listener : listeners) {
@@ -193,7 +198,7 @@ public abstract class AluminaPlugin extends JavaPlugin {
      * This method is used to load a file from the plugin's resources folder.
      * @param name The name of the file to load.
      */
-    public void loadFile(@NotNull String name) {
+    public void loadFile(final String name) {
         FileLoader.loadFile(this, name);
     }
 
@@ -221,7 +226,6 @@ public abstract class AluminaPlugin extends JavaPlugin {
         return instance;
     }
 
-    @NotNull
     public ColorAgent getColorAgent() {
         // Complete null-safety check.
         if (this.colorAgent == null)
@@ -230,7 +234,9 @@ public abstract class AluminaPlugin extends JavaPlugin {
         return colorAgent;
     }
 
-    public void setColorAgent(@NotNull ColorAgent colorAgent) {
+    public void setColorAgent(final ColorAgent colorAgent) {
+        Preconditions.checkNotNull(colorAgent, "Color Agent cannot be null!");
+
         this.colorAgent = colorAgent;
     }
 }

--- a/src/main/java/games/negative/alumina/builder/ItemBuilder.java
+++ b/src/main/java/games/negative/alumina/builder/ItemBuilder.java
@@ -44,7 +44,6 @@ import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.profile.PlayerProfile;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -62,7 +61,9 @@ public class ItemBuilder {
      * Creates a new {@link ItemBuilder} instance from an existing {@link ItemStack}.
      * @param item The item to create the builder from.
      */
-    public ItemBuilder(@NotNull ItemStack item) {
+    public ItemBuilder(final ItemStack item) {
+        Preconditions.checkNotNull(item, "Item cannot be null!");
+
         this.item = item.clone();
         this.meta = this.item.getItemMeta();
 
@@ -73,7 +74,9 @@ public class ItemBuilder {
      * Creates a new {@link ItemBuilder} instance from an existing {@link ItemBuilder}.
      * @param builder The builder to create the builder from.
      */
-    public ItemBuilder(@NotNull ItemBuilder builder) {
+    public ItemBuilder(final ItemBuilder builder) {
+        Preconditions.checkNotNull(builder, "ItemBuilder cannot be null!");
+
         this.item = builder.item.clone();
         this.meta = builder.meta.clone();
     }
@@ -82,7 +85,7 @@ public class ItemBuilder {
      * Creates a new {@link ItemBuilder} instance from the provided {@link Material}.
      * @param material The material to create the builder from.
      */
-    public ItemBuilder(@NotNull Material material) {
+    public ItemBuilder(final Material material) {
         this(new ItemStack(material));
     }
 
@@ -91,7 +94,7 @@ public class ItemBuilder {
      * @param material The material to create the builder from.
      * @param amount The amount of the item.
      */
-    public ItemBuilder(@NotNull Material material, int amount) {
+    public ItemBuilder(final Material material, final int amount) {
         this(new ItemStack(material, amount));
     }
 
@@ -100,8 +103,9 @@ public class ItemBuilder {
      * @param text The text to set the display name to.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder setName(@NotNull String text) {
+    public ItemBuilder setName(final String text) {
+        Preconditions.checkNotNull(text, "Text cannot be null!");
+
         this.meta.setDisplayName(ColorUtil.translate(text));
         return this;
     }
@@ -112,8 +116,10 @@ public class ItemBuilder {
      * @param replacement The replacement for the placeholder.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder replaceName(@NotNull String placeholder, @NotNull String replacement) {
+    public ItemBuilder replaceName(final String placeholder, final String replacement) {
+        Preconditions.checkNotNull(placeholder, "Placeholder cannot be null!");
+        Preconditions.checkNotNull(replacement, "Replacement cannot be null!");
+
         return this.setName(this.meta.getDisplayName().replace(placeholder, replacement));
     }
 
@@ -123,7 +129,10 @@ public class ItemBuilder {
      * @return The current instance of the builder.
      */
     @NotNull
-    public ItemBuilder setLore(@NotNull String... text) {
+    public ItemBuilder setLore(final String... text) {
+        Preconditions.checkNotNull(text, "Text cannot be null!");
+        Preconditions.checkArgument(text.length > 0, "Text cannot be empty!");
+
         List<String> parsed = Lists.newArrayList();
 
         for (String line : text) {
@@ -139,8 +148,10 @@ public class ItemBuilder {
      * @param text The text to set the lore to.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder setLore(@NotNull List<String> text) {
+    public ItemBuilder setLore(final List<String> text) {
+        Preconditions.checkNotNull(text, "Text cannot be null!");
+        Preconditions.checkArgument(!text.isEmpty(), "Text cannot be empty!");
+
         List<String> parsed = Lists.newArrayList();
 
         for (String line : text) {
@@ -156,8 +167,9 @@ public class ItemBuilder {
      * @param text The text to add to the lore.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder addLoreLine(@NotNull String text) {
+    public ItemBuilder addLoreLine(final String text) {
+        Preconditions.checkNotNull(text, "Text cannot be null!");
+
         List<String> lore = this.meta.getLore();
         if (lore == null) lore = Lists.newArrayList();
 
@@ -172,8 +184,10 @@ public class ItemBuilder {
      * @param text The text to add to the lore.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder addLoreLines(@NotNull String... text) {
+    public ItemBuilder addLoreLines(final String... text) {
+        Preconditions.checkNotNull(text, "Text cannot be null!");
+        Preconditions.checkArgument(text.length > 0, "Text cannot be empty!");
+
         List<String> lore = this.meta.getLore();
         if (lore == null) lore = Lists.newArrayList();
 
@@ -191,8 +205,10 @@ public class ItemBuilder {
      * @param text The text to add to the lore.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder addLoreLines(@NotNull List<String> text) {
+    public ItemBuilder addLoreLines(final List<String> text) {
+        Preconditions.checkNotNull(text, "Text cannot be null!");
+        Preconditions.checkArgument(!text.isEmpty(), "Text cannot be empty!");
+
         List<String> lore = this.meta.getLore();
         if (lore == null) lore = Lists.newArrayList();
 
@@ -210,8 +226,9 @@ public class ItemBuilder {
      * @param function The function to replace the lore.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder replaceLore(@NotNull UnaryOperator<String> function) {
+    public ItemBuilder replaceLore(final UnaryOperator<String> function) {
+        Preconditions.checkNotNull(function, "Function cannot be null!");
+
         List<String> lore = this.meta.getLore();
         if (lore == null) lore = Lists.newArrayList();
 
@@ -227,8 +244,10 @@ public class ItemBuilder {
      * @param replacement The replacement for the placeholder.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder replaceLore(@NotNull String placeholder, @NotNull String replacement) {
+    public ItemBuilder replaceLore(final String placeholder, final String replacement) {
+        Preconditions.checkNotNull(placeholder, "Placeholder cannot be null!");
+        Preconditions.checkNotNull(replacement, "Replacement cannot be null!");
+
         return this.replaceLore(line -> line.replace(placeholder, replacement));
     }
 
@@ -238,8 +257,10 @@ public class ItemBuilder {
      * @param level The level of the enchantment.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder addEnchantment(@NotNull Enchantment enchantment, int level) {
+    public ItemBuilder addEnchantment(final Enchantment enchantment, final int level) {
+        Preconditions.checkNotNull(enchantment, "Enchantment cannot be null!");
+        Preconditions.checkArgument(level > 0, "Level must be greater than 0!");
+
         this.meta.addEnchant(enchantment, level, true);
         return this;
     }
@@ -249,8 +270,9 @@ public class ItemBuilder {
      * @param enchantment The enchantment to remove.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder removeEnchantment(@NotNull Enchantment enchantment) {
+    public ItemBuilder removeEnchantment(final Enchantment enchantment) {
+        Preconditions.checkNotNull(enchantment, "Enchantment cannot be null!");
+
         this.meta.removeEnchant(enchantment);
         return this;
     }
@@ -260,8 +282,7 @@ public class ItemBuilder {
      * @param unbreakable Whether the item should be unbreakable.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder setUnbreakable(boolean unbreakable) {
+    public ItemBuilder setUnbreakable(final boolean unbreakable) {
         this.meta.setUnbreakable(unbreakable);
         return this;
     }
@@ -271,8 +292,10 @@ public class ItemBuilder {
      * @param flags The flags to add.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder addItemFlags(@NotNull ItemFlag... flags) {
+    public ItemBuilder addItemFlags(final ItemFlag... flags) {
+        Preconditions.checkNotNull(flags, "Flags cannot be null!");
+        Preconditions.checkArgument(flags.length > 0, "Flags cannot be empty!");
+
         this.meta.addItemFlags(flags);
         return this;
     }
@@ -282,8 +305,10 @@ public class ItemBuilder {
      * @param flags The flags to remove.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder removeItemFlags(@NotNull ItemFlag... flags) {
+    public ItemBuilder removeItemFlags(final ItemFlag... flags) {
+        Preconditions.checkNotNull(flags, "Flags cannot be null!");
+        Preconditions.checkArgument(flags.length > 0, "Flags cannot be empty!");
+
         this.meta.removeItemFlags(flags);
         return this;
     }
@@ -294,8 +319,9 @@ public class ItemBuilder {
      * @return The current instance of the builder.
      * @throws ClassCastException If the item is not a skull.
      */
-    @NotNull
-    public ItemBuilder setSkullOwner(@NotNull OfflinePlayer player) {
+    public ItemBuilder setSkullOwner(final OfflinePlayer player) {
+        Preconditions.checkNotNull(player, "Player cannot be null!");
+
         SkullMeta skullMeta = (SkullMeta) this.meta;
         skullMeta.setOwningPlayer(player);
         return this;
@@ -307,8 +333,8 @@ public class ItemBuilder {
      * @return The current instance of the builder.
      * @throws ClassCastException If the item is not a skull.
      */
-    @NotNull
-    public ItemBuilder setSkullOwner(@NotNull PlayerProfile profile) {
+    public ItemBuilder setSkullOwner(final PlayerProfile profile) {
+        Preconditions.checkNotNull(profile, "Profile cannot be null!");
         SkullMeta skullMeta = (SkullMeta) this.meta;
         skullMeta.setOwnerProfile(profile);
         return this;
@@ -319,8 +345,7 @@ public class ItemBuilder {
      * @param data The custom model data to set.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder setCustomModelData(int data) {
+    public ItemBuilder setCustomModelData(final Integer data) {
         this.meta.setCustomModelData(data);
         return this;
     }
@@ -331,8 +356,7 @@ public class ItemBuilder {
      * @return The current instance of the builder.
      * @throws ClassCastException If the item is not a leather armor piece.
      */
-    @NotNull
-    public ItemBuilder setLeatherColor(@Nullable Color color) {
+    public ItemBuilder setLeatherColor(final Color color) {
         LeatherArmorMeta leatherArmorMeta = (LeatherArmorMeta) this.meta;
         leatherArmorMeta.setColor(color);
         return this;
@@ -343,8 +367,9 @@ public class ItemBuilder {
      * @param function The function to apply the persistent data.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder applyPersistentData(@NotNull Consumer<PersistentDataContainer> function) {
+    public ItemBuilder applyPersistentData(final Consumer<PersistentDataContainer> function) {
+        Preconditions.checkNotNull(function, "Function cannot be null!");
+
         function.accept(this.meta.getPersistentDataContainer());
         return this;
     }
@@ -355,8 +380,10 @@ public class ItemBuilder {
      * @param modifier The modifier to add.
      * @return The current instance of the builder.
      */
-    @NotNull
     public ItemBuilder addAttributeModifier(@NotNull Attribute attribute, @NotNull AttributeModifier modifier) {
+        Preconditions.checkNotNull(attribute, "Attribute cannot be null!");
+        Preconditions.checkNotNull(modifier, "Modifier cannot be null!");
+
         this.meta.addAttributeModifier(attribute, modifier);
         return this;
     }
@@ -366,8 +393,9 @@ public class ItemBuilder {
      * @param attribute The attribute to remove the modifier from.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder removeAttributeModifier(@NotNull Attribute attribute) {
+    public ItemBuilder removeAttributeModifier(final Attribute attribute) {
+        Preconditions.checkNotNull(attribute, "Attribute cannot be null!");
+
         this.meta.removeAttributeModifier(attribute);
         return this;
     }
@@ -378,8 +406,10 @@ public class ItemBuilder {
      * @param modifier The modifier to remove.
      * @return The current instance of the builder.
      */
-    @NotNull
-    public ItemBuilder removeAttributeModifier(@NotNull Attribute attribute, @NotNull AttributeModifier modifier) {
+    public ItemBuilder removeAttributeModifier(final Attribute attribute, final AttributeModifier modifier) {
+        Preconditions.checkNotNull(attribute, "Attribute cannot be null!");
+        Preconditions.checkNotNull(modifier, "Modifier cannot be null!");
+
         this.meta.removeAttributeModifier(attribute, modifier);
         return this;
     }
@@ -388,7 +418,6 @@ public class ItemBuilder {
      * Construct the {@link ItemStack} from the builder.
      * @return The constructed {@link ItemStack}.
      */
-    @NotNull
     public ItemStack build() {
         this.item.setItemMeta(this.meta);
         return this.item;

--- a/src/main/java/games/negative/alumina/command/Command.java
+++ b/src/main/java/games/negative/alumina/command/Command.java
@@ -25,9 +25,6 @@
 
 package games.negative.alumina.command;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.List;
 
 /**
@@ -45,7 +42,7 @@ public interface Command {
      * This method is called when the command is executed.
      * @param context The context of the command.
      */
-    void execute(@NotNull Context context);
+    void execute(Context context);
 
     /**
      * This method is called when the command is tab completed.
@@ -53,8 +50,7 @@ public interface Command {
      * @return a list of possible completions for the command.
      * @apiNote This method is optional, override to add proper functionality.
      */
-    @Nullable
-    default List<String> onTabComplete(@NotNull TabContext context) {
+    default List<String> onTabComplete(TabContext context) {
         return null;
     }
 }

--- a/src/main/java/games/negative/alumina/command/Context.java
+++ b/src/main/java/games/negative/alumina/command/Context.java
@@ -25,11 +25,10 @@
 
 package games.negative.alumina.command;
 
+import com.google.common.base.Preconditions;
 import games.negative.alumina.message.Message;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -39,18 +38,7 @@ import java.util.Optional;
  * @param args The arguments of the command
  * @param sender The sender of the command
  */
-public record Context(@NotNull String[] args, @NotNull CommandSender sender) {
-
-    /**
-     * Returns the player who executed the command.
-     * @throws NullPointerException if the sender is not a player.
-     * @return the player who executed the command.
-     */
-    @Deprecated
-    @Nullable
-    public Player getPlayer() {
-        return sender() instanceof Player ? (Player) sender() : null;
-    }
+public record Context(String[] args, CommandSender sender) {
 
     /**
      * Returns the player who executed the command.
@@ -65,8 +53,7 @@ public record Context(@NotNull String[] args, @NotNull CommandSender sender) {
      * @param index The index of the argument.
      * @return the argument at the specified index.
      */
-    @NotNull
-    public Optional<String> argument(int index) {
+    public Optional<String> argument(final int index) {
         return (index >= args.length ? Optional.empty() : Optional.of(args[index]));
     }
 
@@ -74,7 +61,9 @@ public record Context(@NotNull String[] args, @NotNull CommandSender sender) {
      * Send a message to the sender of the command.
      * @param message The message to send.
      */
-    public void message(@NotNull String message) {
+    public void message(final String message) {
+        Preconditions.checkNotNull(message, "message cannot be null");
+
         sender().sendMessage(message);
     }
 
@@ -82,7 +71,9 @@ public record Context(@NotNull String[] args, @NotNull CommandSender sender) {
      * Send a message to the sender of the command.
      * @param message The message to send.
      */
-    public void message(@NotNull Message message) {
+    public void message(final Message message) {
+        Preconditions.checkNotNull(message, "message cannot be null");
+
         message.send(sender());
     }
 }

--- a/src/main/java/games/negative/alumina/command/TabContext.java
+++ b/src/main/java/games/negative/alumina/command/TabContext.java
@@ -3,7 +3,6 @@ package games.negative.alumina.command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 
@@ -12,7 +11,7 @@ import java.util.Optional;
  * @param args The arguments of the command.
  * @param sender The sender of the command.
  */
-public record TabContext(@NotNull CommandSender sender, @NotNull String[] args) {
+public record TabContext(CommandSender sender, String[] args) {
 
     /**
      * Returns the player who executed the command.
@@ -28,7 +27,7 @@ public record TabContext(@NotNull CommandSender sender, @NotNull String[] args) 
      * @return the argument at the specified index.
      */
     @NotNull
-    public Optional<String> argument(int index) {
+    public Optional<String> argument(final int index) {
         return (index >= args.length ? Optional.empty() : Optional.of(args[index]));
     }
 
@@ -36,7 +35,6 @@ public record TabContext(@NotNull CommandSender sender, @NotNull String[] args) 
      * Returns the current argument used in the command.
      * @return the current argument.
      */
-    @NotNull
     public String current() {
         return argument(args.length - 1).orElseThrow(() -> new IllegalStateException("No current argument"));
     }

--- a/src/main/java/games/negative/alumina/command/builder/CommandBuilder.java
+++ b/src/main/java/games/negative/alumina/command/builder/CommandBuilder.java
@@ -31,8 +31,6 @@ import games.negative.alumina.command.Command;
 import games.negative.alumina.command.structure.AluminaCommand;
 import lombok.Getter;
 import org.bukkit.permissions.Permission;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -70,7 +68,9 @@ public class CommandBuilder {
      * Creates a new command builder.
      * @param component The command component.
      */
-    public CommandBuilder(@NotNull Command component) {
+    public CommandBuilder(final Command component) {
+        Preconditions.checkNotNull(component, "Command component cannot be null.");
+
         this.component = component;
         this.subCommands = Lists.newArrayList();
         this.aliases = Lists.newArrayList();
@@ -84,8 +84,9 @@ public class CommandBuilder {
      * @param name The name of the command.
      * @return The command builder.
      */
-    public CommandBuilder name(@NotNull String name) {
+    public CommandBuilder name(final String name) {
         Preconditions.checkNotNull(name, "Command name cannot be null.");
+
         this.name = name;
         return this;
     }
@@ -95,7 +96,7 @@ public class CommandBuilder {
      * @param description The description of the command.
      * @return The command builder.
      */
-    public CommandBuilder description(@NotNull String description) {
+    public CommandBuilder description(final String description) {
         Preconditions.checkNotNull(description, "Command description cannot be null.");
         this.description = description;
         return this;
@@ -106,7 +107,7 @@ public class CommandBuilder {
      * @param usage The usage of the command.
      * @return The command builder.
      */
-    public CommandBuilder usage(@NotNull String usage) {
+    public CommandBuilder usage(final String usage) {
         Preconditions.checkNotNull(usage, "Command usage message cannot be null.");
         this.usage = usage;
         return this;
@@ -117,8 +118,10 @@ public class CommandBuilder {
      * @param aliases The aliases of the command.
      * @return The command builder.
      */
-    public CommandBuilder aliases(@NotNull String... aliases) {
+    public CommandBuilder aliases(final String... aliases) {
         Preconditions.checkNotNull(aliases, "Command aliases cannot be null.");
+        Preconditions.checkArgument(aliases.length > 0, "Command aliases cannot be empty.");
+
         return aliases(Lists.newArrayList(aliases));
     }
 
@@ -127,8 +130,10 @@ public class CommandBuilder {
      * @param aliases The aliases of the command.
      * @return The command builder.
      */
-    public CommandBuilder aliases(@NotNull List<String> aliases) {
+    public CommandBuilder aliases(final List<String> aliases) {
         Preconditions.checkNotNull(aliases, "Command aliases cannot be null.");
+        Preconditions.checkArgument(!aliases.isEmpty(), "Command aliases cannot be empty.");
+
         this.aliases = aliases;
         return this;
     }
@@ -138,8 +143,10 @@ public class CommandBuilder {
      * @param permissions The permissions of the command.
      * @return The command builder.
      */
-    public CommandBuilder permission(@NotNull Permission... permissions) {
+    public CommandBuilder permission(final Permission... permissions) {
         Preconditions.checkNotNull(permissions, "Command permissions cannot be null.");
+        Preconditions.checkArgument(permissions.length > 0, "Command permissions cannot be empty.");
+
         this.permissions = permissions;
         return this;
     }
@@ -149,8 +156,10 @@ public class CommandBuilder {
      * @param permissions The permissions of the command.
      * @return The command builder.
      */
-    public CommandBuilder permission(@NotNull String... permissions) {
+    public CommandBuilder permission(final String... permissions) {
         Preconditions.checkNotNull(permissions, "Command permissions cannot be null.");
+        Preconditions.checkArgument(permissions.length > 0, "Command permissions cannot be empty.");
+
         this.permissions = Arrays.stream(permissions).map(Permission::new).toArray(Permission[]::new);
         return this;
     }
@@ -160,8 +169,9 @@ public class CommandBuilder {
      * @param permission The permission of the command.
      * @return The command builder.
      */
-    public CommandBuilder permission(@NotNull Permission permission) {
+    public CommandBuilder permission(final Permission permission) {
         Preconditions.checkNotNull(permission, "Command permission cannot be null.");
+
         this.permissions = new Permission[] { permission };
         return this;
     }
@@ -171,7 +181,9 @@ public class CommandBuilder {
      * @param permission The permission of the command.
      * @return The command builder.
      */
-    public CommandBuilder permission(@NotNull String permission) {
+    public CommandBuilder permission(final String permission) {
+        Preconditions.checkNotNull(permission, "Command permission cannot be null.");
+
         return this.permission(new Permission(permission));
     }
 
@@ -180,8 +192,10 @@ public class CommandBuilder {
      * @param permission The permissions of the command.
      * @return The command builder.
      */
-    public CommandBuilder permission(@NotNull List<Permission> permission) {
+    public CommandBuilder permission(final List<Permission> permission) {
         Preconditions.checkNotNull(permission, "Command permission cannot be null.");
+        Preconditions.checkArgument(!permission.isEmpty(), "Command permission cannot be empty.");
+
         this.permissions = permission.toArray(new Permission[0]);
         return this;
     }
@@ -191,8 +205,10 @@ public class CommandBuilder {
      * @param params The parameters of the command.
      * @return The command builder.
      */
-    public CommandBuilder params(@NotNull String... params) {
+    public CommandBuilder params(final String... params) {
         Preconditions.checkNotNull(params, "Command params cannot be null.");
+        Preconditions.checkArgument(params.length > 0, "Command params cannot be empty.");
+
         this.params = params;
         return this;
     }
@@ -202,8 +218,10 @@ public class CommandBuilder {
      * @param shortcuts The shortcuts of the command.
      * @return The command builder.
      */
-    public CommandBuilder shortcuts(@NotNull String... shortcuts) {
+    public CommandBuilder shortcuts(final String... shortcuts) {
         Preconditions.checkNotNull(shortcuts, "Command shortcuts cannot be null.");
+        Preconditions.checkArgument(shortcuts.length > 0, "Command shortcuts cannot be empty.");
+
         this.shortcuts = shortcuts;
         return this;
     }
@@ -219,8 +237,10 @@ public class CommandBuilder {
         return this;
     }
 
-    public CommandBuilder subcommands(CommandBuilder... commands) {
+    public CommandBuilder subcommands(final CommandBuilder... commands) {
         Preconditions.checkNotNull(commands, "Command subcommands cannot be null.");
+        Preconditions.checkArgument(commands.length > 0, "Command subcommands cannot be empty.");
+
         subCommands.addAll(Arrays.asList(commands));
         return this;
     }
@@ -240,7 +260,7 @@ public class CommandBuilder {
      * @param value The value of the smart tab complete.
      * @return The command builder.
      */
-    public CommandBuilder smartTabComplete(boolean value) {
+    public CommandBuilder smartTabComplete(final boolean value) {
         this.smartTabComplete = value;
         return this;
     }
@@ -258,7 +278,7 @@ public class CommandBuilder {
      * @param parent The parent command.
      * @return The command builder.
      */
-    public AluminaCommand build(@Nullable AluminaCommand parent) {
+    public AluminaCommand build(final AluminaCommand parent) {
         return new AluminaCommand(parent, this);
     }
 

--- a/src/main/java/games/negative/alumina/command/structure/AluminaCommand.java
+++ b/src/main/java/games/negative/alumina/command/structure/AluminaCommand.java
@@ -38,7 +38,6 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.permissions.Permission;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -56,7 +55,7 @@ public class AluminaCommand extends org.bukkit.command.Command {
     private static final Message NO_PERMISSION = Message.of("&cYou do not have permission to use this command.");
 
     /*
-     * The message for when a player-only command is used as console.
+     * The message for when a player-only command is used as a console.
      */
     private static final Message CANNOT_USE_AS_CONSOLE = Message.of("&cYou cannot use this command as console.");
 
@@ -112,8 +111,10 @@ public class AluminaCommand extends org.bukkit.command.Command {
      * @param parent  The parent command.
      * @param builder The command builder.
      */
-    public AluminaCommand(@Nullable AluminaCommand parent, @NotNull CommandBuilder builder) {
+    public AluminaCommand(final AluminaCommand parent, final CommandBuilder builder) {
         super(builder.getName(), builder.getDescription(), builder.getUsage(), builder.getAliases());
+
+        Preconditions.checkNotNull(builder, "Command builder cannot be null.");
 
         this.parent = parent;
 
@@ -177,8 +178,9 @@ public class AluminaCommand extends org.bukkit.command.Command {
         return result;
     }
 
-    @NotNull
-    private Multimap<Integer, AluminaCommand> getRecursive(@NotNull AluminaCommand parent, int depth) {
+    private Multimap<Integer, AluminaCommand> getRecursive(final AluminaCommand parent, final int depth) {
+        Preconditions.checkNotNull(parent, "Parent command cannot be null.");
+
         Multimap<Integer, AluminaCommand> map = ArrayListMultimap.create();
 
         List<AluminaCommand> list = parent.getSubCommands();
@@ -201,7 +203,9 @@ public class AluminaCommand extends org.bukkit.command.Command {
      * @param sender The sender
      * @return Whether the console is using a player-only command
      */
-    private boolean checkConsolePlayerCommand(@NotNull CommandSender sender) {
+    private boolean checkConsolePlayerCommand(final CommandSender sender) {
+        Preconditions.checkNotNull(sender, "Sender cannot be null.");
+
         if (!(sender instanceof Player) && playerOnly) {
             CANNOT_USE_AS_CONSOLE.send(sender);
             return true;
@@ -210,7 +214,9 @@ public class AluminaCommand extends org.bukkit.command.Command {
         return false;
     }
 
-    private boolean checkPermissions(@NotNull CommandSender sender, boolean message) {
+    private boolean checkPermissions(final CommandSender sender, final boolean message) {
+        Preconditions.checkNotNull(sender, "Sender cannot be null.");
+
         if (this.permissions == null)
             return true;
 
@@ -223,7 +229,10 @@ public class AluminaCommand extends org.bukkit.command.Command {
         return false;
     }
 
-    private boolean checkSubCommands(@NotNull CommandSender sender, @NotNull String[] args) {
+    private boolean checkSubCommands(final CommandSender sender, final String[] args) {
+        Preconditions.checkNotNull(sender, "Sender cannot be null.");
+        Preconditions.checkNotNull(args, "Arguments cannot be null.");
+
         if (args.length == 0 || subCommands.isEmpty())
             return false;
 
@@ -234,8 +243,9 @@ public class AluminaCommand extends org.bukkit.command.Command {
         return (subCommand != null && subCommand.execute(sender, begin, snippet));
     }
 
-    @Nullable
-    public AluminaCommand getAvailableSubCommand(@NotNull String argument) {
+    public AluminaCommand getAvailableSubCommand(final String argument) {
+        Preconditions.checkNotNull(argument, "Argument cannot be null.");
+
         for (AluminaCommand subCommand : subCommands) {
             if (subCommand.getName().equalsIgnoreCase(argument) || subCommand.getAliases().contains(argument.toLowerCase()))
                 return subCommand;
@@ -243,7 +253,10 @@ public class AluminaCommand extends org.bukkit.command.Command {
         return null;
     }
 
-    public boolean checkParams(@NotNull CommandSender sender, @NotNull String[] args) {
+    public boolean checkParams(final CommandSender sender, final String[] args) {
+        Preconditions.checkNotNull(sender, "Sender cannot be null.");
+        Preconditions.checkNotNull(args, "Arguments cannot be null.");
+
         if (this.params == null)
             return true;
 

--- a/src/main/java/games/negative/alumina/event/Events.java
+++ b/src/main/java/games/negative/alumina/event/Events.java
@@ -25,9 +25,9 @@
 
 package games.negative.alumina.event;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Event;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Events utility class for more simply calling events
@@ -39,7 +39,9 @@ public class Events {
      *
      * @param event Event to call
      */
-    public static <T extends Event> void call(@NotNull T event) {
+    public static <T extends Event> void call(final T event) {
+        Preconditions.checkNotNull(event, "Event cannot be null");
+
         Bukkit.getPluginManager().callEvent(event);
     }
 

--- a/src/main/java/games/negative/alumina/menu/ChestMenu.java
+++ b/src/main/java/games/negative/alumina/menu/ChestMenu.java
@@ -47,13 +47,10 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayDeque;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Queue;
-import java.util.logging.Logger;
 
 /**
  * Represents a intractable chest menu.
@@ -76,7 +73,8 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param rows The amount of rows the menu should have.
      * @apiNote The number of rows must be greater than 0 and less than or equal to 6.
      */
-    public ChestMenu(@NotNull String title, int rows) {
+    public ChestMenu(final String title, final int rows) {
+        Preconditions.checkNotNull(title, "title cannot be null");
         Preconditions.checkArgument(MathUtil.between(rows, 1, 6), "Rows must be greater than 0 and less than or equal to 6.");
 
         this.rows = rows;
@@ -103,7 +101,9 @@ public abstract class ChestMenu implements AluminaMenu {
      *                    When the function key is null, the item will not be functional.
      */
     @Override
-    public void setItem(int slot, @NotNull ItemStack item, @Nullable String functionKey) {
+    public void setItem(final int slot, final ItemStack item, final String functionKey) {
+        Preconditions.checkNotNull(item, "item cannot be null");
+
         if (this.freeSlots != null)
             this.freeSlots.remove(slot);
 
@@ -127,7 +127,9 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param functionKey The function key to set.
      */
     @Override
-    public void addItem(@NotNull ItemStack item, @Nullable String functionKey) {
+    public void addItem(final ItemStack item, final String functionKey) {
+        Preconditions.checkNotNull(item, "item cannot be null");
+
         // We're using a set to store the free slots, so we do not need to loop through the entire inventory
         // whenever we need to find a free slot.
         // Even tho in the grand scheme of things, it's a micro-performance boost, it's still a boost, I guess.
@@ -152,7 +154,9 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param item The item.
      * @param key The function key.
      */
-    private void applyFunction(@NotNull ItemStack item, @Nullable String key) {
+    private void applyFunction(final ItemStack item, final String key) {
+        Preconditions.checkNotNull(item, "item cannot be null");
+
         if (key == null) return;
 
         ItemMeta meta = item.getItemMeta();
@@ -168,7 +172,7 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param slot The slot to clear.
      */
     @Override
-    public void clearSlot(int slot) {
+    public void clearSlot(final int slot) {
         inventory.clear(slot);
 
         if (freeSlots != null && !freeSlots.contains(slot)) freeSlots.add(slot);
@@ -183,8 +187,10 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param player The player to open the menu for.
      */
     @Override
-    public void open(@NotNull Player player) {
-        refresh(player);
+    public void open(final Player player) {
+        Preconditions.checkNotNull(player, "player cannot be null");
+
+        refresh();
 
         player.openInventory(inventory);
     }
@@ -193,7 +199,7 @@ public abstract class ChestMenu implements AluminaMenu {
      * This method will allow you to refresh the menu.
      */
     @Override
-    public void refresh(@Nullable Player player) {
+    public void refresh() {
         if (inventory == null) this.inventory = Bukkit.createInventory(new ChestMenuHolder(this), (rows * 9), ColorUtil.translate(title));
 
         inventory.clear();
@@ -209,7 +215,9 @@ public abstract class ChestMenu implements AluminaMenu {
      * This method will allow you to set the menu title.
      * @param title The title to set.
      */
-    public void setTitle(@NotNull String title) {
+    public void setTitle(final String title) {
+        Preconditions.checkNotNull(title, "title cannot be null");
+
         this.title = title;
 
         updateTitle();
@@ -232,7 +240,7 @@ public abstract class ChestMenu implements AluminaMenu {
         }
     }
 
-    public void setRows(int rows) {
+    public void setRows(final int rows) {
         Preconditions.checkArgument(MathUtil.between(rows, 1, 6), "Rows must be greater than 0 and less than or equal to 6.");
 
         this.rows = rows;
@@ -244,7 +252,7 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param event  The event.
      */
     @Override
-    public void onClick(@NotNull Player player, @NotNull InventoryClickEvent event) {
+    public void onClick(final Player player, final InventoryClickEvent event) {
         // Override this method to handle clicks.
     }
 
@@ -256,7 +264,7 @@ public abstract class ChestMenu implements AluminaMenu {
      * @deprecated Use {@link #onFunctionClick(Player, String, InventoryClickEvent)} instead.
      */
     @Override
-    public void onFunctionClick(@NotNull Player player, @NotNull MenuItem item, @NotNull InventoryClickEvent event) {
+    public void onFunctionClick(final Player player, final MenuItem item, final InventoryClickEvent event) {
         // Override this method to handle function clicks.
     }
 
@@ -277,7 +285,7 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param event  The event.
      */
     @Override
-    public void onClose(@NotNull Player player, @NotNull InventoryCloseEvent event) {
+    public void onClose(final Player player, InventoryCloseEvent event) {
         // Override this method to handle close.
     }
 
@@ -287,7 +295,7 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param event  The event.
      */
     @Override
-    public void onOpen(@NotNull Player player, @NotNull InventoryOpenEvent event) {
+    public void onOpen(final Player player, final InventoryOpenEvent event) {
         // Override this method to handle open.
     }
 
@@ -320,7 +328,6 @@ public abstract class ChestMenu implements AluminaMenu {
      * @param key The function key.
      * @return The menu item.
      */
-    @Nullable
     public MenuItem byKey(@NotNull String key) {
         return byKey.getOrDefault(key, null);
     }

--- a/src/main/java/games/negative/alumina/menu/base/AluminaMenu.java
+++ b/src/main/java/games/negative/alumina/menu/base/AluminaMenu.java
@@ -34,8 +34,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents the base class for all custom menus.
@@ -55,7 +53,7 @@ public interface AluminaMenu {
      * @param functionKey The function key to set.
      *                    When the function key is null, the item will not be functional.
      */
-    void setItem(int slot, @NotNull ItemStack item, @Nullable String functionKey);
+    void setItem(int slot, final ItemStack item, final String functionKey);
 
     /**
      * This method will allow you to set a non-functional item in the menu.
@@ -63,7 +61,7 @@ public interface AluminaMenu {
      * @param slot The slot to set the item in.
      * @param item The item to set.
      */
-    default void setItem(int slot, @NotNull ItemStack item) {
+    default void setItem(final int slot, final ItemStack item) {
         setItem(slot, item, null);
     }
 
@@ -72,13 +70,13 @@ public interface AluminaMenu {
      * @param item The item to add.
      * @param functionKey The function key to set.
      */
-    void addItem(@NotNull ItemStack item, @Nullable String functionKey);
+    void addItem(final ItemStack item, final String functionKey);
 
     /**
      * This method will allow you to add a non-functional item to the menu.
      * @param item The item to add.
      */
-    default void addItem(@NotNull ItemStack item) {
+    default void addItem(final ItemStack item) {
         addItem(item, null);
     }
 
@@ -87,19 +85,19 @@ public interface AluminaMenu {
      *
      * @param slot The slot to clear.
      */
-    void clearSlot(int slot);
+    void clearSlot(final int slot);
 
     /**
      * This method will allow you to open the menu for a player.
      *
      * @param player The player to open the menu for.
      */
-    void open(@NotNull Player player);
+    void open(final Player player);
 
     /**
      * This method will allow you to refresh the menu.
      */
-    void refresh(@Nullable Player player);
+    void refresh();
 
     /**
      * This method will allow you to listen to the open event of the menu.
@@ -107,7 +105,7 @@ public interface AluminaMenu {
      * @param player The player who opened the menu.
      * @param event  The event.
      */
-    void onOpen(@NotNull Player player, @NotNull InventoryOpenEvent event);
+    void onOpen(final Player player, final InventoryOpenEvent event);
 
     /**
      * This method will allow you to listen to the close event of the menu.
@@ -115,7 +113,7 @@ public interface AluminaMenu {
      * @param player The player who closed the menu.
      * @param event  The event.
      */
-    void onClose(@NotNull Player player, @NotNull InventoryCloseEvent event);
+    void onClose(final Player player, final InventoryCloseEvent event);
 
     /**
      * This method will allow you to listen to the click event of the menu.
@@ -123,7 +121,7 @@ public interface AluminaMenu {
      * @param player The player who clicked the menu.
      * @param event  The event.
      */
-    void onClick(@NotNull Player player, @NotNull InventoryClickEvent event);
+    void onClick(final Player player, final InventoryClickEvent event);
 
     /**
      * This method will allow you to listen to the function click event of the menu.
@@ -134,7 +132,7 @@ public interface AluminaMenu {
      * @deprecated Use {@link #onFunctionClick(Player, String, InventoryClickEvent)} instead.
      */
     @Deprecated
-    void onFunctionClick(@NotNull Player player, @NotNull MenuItem item, @NotNull InventoryClickEvent event);
+    void onFunctionClick(final Player player, final MenuItem item, final InventoryClickEvent event);
 
     /**
      * This method will allow you to listen to the function click event of the menu.
@@ -142,5 +140,5 @@ public interface AluminaMenu {
      * @param key The function key.
      * @param event The event.
      */
-    void onFunctionClick(@NotNull Player player, @NotNull String key, @NotNull InventoryClickEvent event);
+    void onFunctionClick(final Player player, final String key, final InventoryClickEvent event);
 }

--- a/src/main/java/games/negative/alumina/menu/base/AluminaMenuHolder.java
+++ b/src/main/java/games/negative/alumina/menu/base/AluminaMenuHolder.java
@@ -32,7 +32,6 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.inventory.InventoryHolder;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Represents the base menu holder class for all custom menus.
@@ -45,27 +44,26 @@ public interface AluminaMenuHolder<T extends AluminaMenu> extends InventoryHolde
      * @param player The player who opened the menu.
      * @param event The event that was called.
      */
-    void onOpen(@NotNull Player player, @NotNull InventoryOpenEvent event);
+    void onOpen(final Player player, final InventoryOpenEvent event);
 
     /**
      * This method will be called when the menu is closed.
      * @param player The player who closed the menu.
      * @param event The event that was called.
      */
-    void onClose(@NotNull Player player, @NotNull InventoryCloseEvent event);
+    void onClose(final Player player, final InventoryCloseEvent event);
 
     /**
      * This method will be called when the player clicks on an item in the menu.
      * @param player The player who clicked on the item.
      * @param event The event that was called.
      */
-    void onClick(@NotNull Player player, @NotNull InventoryClickEvent event);
+    void onClick(final Player player, final InventoryClickEvent event);
 
     /**
      * Gets the menu instance.
      * @return The menu instance.
      */
-    @NotNull
     T getMenu();
 
 }

--- a/src/main/java/games/negative/alumina/menu/base/MenuItem.java
+++ b/src/main/java/games/negative/alumina/menu/base/MenuItem.java
@@ -28,13 +28,11 @@
 package games.negative.alumina.menu.base;
 
 import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * Represents a menu item.
  * @param item The item.
  * @param key The function key.
  */
-public record MenuItem(@NotNull ItemStack item, @Nullable String key) {
+public record MenuItem(ItemStack item, String key) {
 }

--- a/src/main/java/games/negative/alumina/menu/filler/FillerItem.java
+++ b/src/main/java/games/negative/alumina/menu/filler/FillerItem.java
@@ -27,14 +27,14 @@
 
 package games.negative.alumina.menu.filler;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.NotNull;
 
 /**
- * This class represents an item that is used to fill empty spaces in a menu.
+ * This class represents an item used to fill empty spaces in a menu.
  */
 public class FillerItem extends ItemStack {
 
@@ -62,8 +62,10 @@ public class FillerItem extends ItemStack {
         BLACK, WHITE, ORANGE, MAGENTA, LIGHT_BLUE, YELLOW, LIME, PINK, GRAY, LIGHT_GRAY, CYAN, PURPLE, BLUE, BROWN, GREEN, RED
     };
 
-    public FillerItem(@NotNull Material type) {
+    public FillerItem(final Material type) {
         super(type);
+
+        Preconditions.checkNotNull(type, "Material cannot be null");
 
         ItemMeta meta = Bukkit.getItemFactory().getItemMeta(type);
         if (meta == null) throw new IllegalStateException("ItemMeta is null");
@@ -85,7 +87,9 @@ public class FillerItem extends ItemStack {
      * @param name the name of the filler item.
      * @return the filler item with the given name.
      */
-    public static FillerItem valueOf(@NotNull String name) {
+    public static FillerItem valueOf(final String name) {
+        Preconditions.checkNotNull(name, "Name cannot be null");
+
         for (FillerItem item : values) {
             if (item.getType().name().equalsIgnoreCase(name)) {
                 return item;
@@ -99,7 +103,9 @@ public class FillerItem extends ItemStack {
      * @param material the material of the filler item.
      * @return the filler item with the given material.
      */
-    public static FillerItem valueOf(@NotNull Material material) {
+    public static FillerItem valueOf(final Material material) {
+        Preconditions.checkNotNull(material, "Material cannot be null");
+
         for (FillerItem item : values) {
             if (item.getType().equals(material)) {
                 return item;

--- a/src/main/java/games/negative/alumina/menu/holder/ChestMenuHolder.java
+++ b/src/main/java/games/negative/alumina/menu/holder/ChestMenuHolder.java
@@ -27,6 +27,7 @@
 
 package games.negative.alumina.menu.holder;
 
+import com.google.common.base.Preconditions;
 import games.negative.alumina.menu.ChestMenu;
 import games.negative.alumina.menu.base.AluminaMenu;
 import games.negative.alumina.menu.base.AluminaMenuHolder;
@@ -47,17 +48,23 @@ public class ChestMenuHolder implements AluminaMenuHolder<ChestMenu> {
     private final ChestMenu gui;
     private Inventory inventory;
 
-    public ChestMenuHolder(@NotNull ChestMenu gui) {
+    public ChestMenuHolder(final ChestMenu gui) {
         this.gui = gui;
     }
 
     @Override
-    public void onOpen(@NotNull Player player, @NotNull InventoryOpenEvent event) {
+    public void onOpen(final Player player, final InventoryOpenEvent event) {
+        Preconditions.checkNotNull(player, "player cannot be null");
+        Preconditions.checkNotNull(event, "event cannot be null");
+
         gui.onOpen(player, event);
     }
 
     @Override
-    public void onClose(@NotNull Player player, @NotNull InventoryCloseEvent event) {
+    public void onClose(final Player player, final InventoryCloseEvent event) {
+        Preconditions.checkNotNull(player, "player cannot be null");
+        Preconditions.checkNotNull(event, "event cannot be null");
+
         gui.onClose(player, event);
     }
 

--- a/src/main/java/games/negative/alumina/message/Message.java
+++ b/src/main/java/games/negative/alumina/message/Message.java
@@ -36,7 +36,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 
@@ -49,7 +48,7 @@ import java.util.List;
 public class Message implements Deliverable<CommandSender> {
 
     /*
-     * This is the color agent that is used to translate color codes.
+     * This is the color agent used to translate color codes.
      */
     private final ColorAgent colorAgent;
 
@@ -73,7 +72,9 @@ public class Message implements Deliverable<CommandSender> {
      *
      * @param text The text of the message.
      */
-    protected Message(@NotNull String text) {
+    protected Message(final String text) {
+        Preconditions.checkNotNull(text, "Text cannot be null.");
+
         this.def = text;
         this.current = text;
         this.colorAgent = AluminaPlugin.getAluminaInstance().getColorAgent();
@@ -86,7 +87,10 @@ public class Message implements Deliverable<CommandSender> {
      * @param replacement The replacement.
      * @return The message.
      */
-    public Message replace(@NotNull String placeholder, @NotNull String replacement) {
+    public Message replace(final String placeholder, final String replacement) {
+        Preconditions.checkNotNull(placeholder, "Placeholder cannot be null.");
+        Preconditions.checkNotNull(replacement, "Replacement cannot be null.");
+
         this.current = this.current.replace(placeholder, replacement);
         return this;
     }
@@ -109,7 +113,9 @@ public class Message implements Deliverable<CommandSender> {
      * @param sender The sender to send the message to.
      */
     @Override
-    public void send(@NotNull CommandSender sender) {
+    public void send(final CommandSender sender) {
+        Preconditions.checkNotNull(sender, "Sender cannot be null.");
+
         String translate = colorAgent.translate(this.current);
         String text = parsePAPI(sender, translate);
         String[] message = text.split("\n");
@@ -127,7 +133,10 @@ public class Message implements Deliverable<CommandSender> {
      * @param iterable The iterable collection of a class that extends {@link CommandSender}
      * @param <T>      The class that extends {@link CommandSender}
      */
-    public <T extends Iterable<? extends CommandSender>> void send(T iterable) {
+    public <T extends Iterable<? extends CommandSender>> void send(final T iterable) {
+        Preconditions.checkNotNull(iterable, "Iterable cannot be null.");
+        Preconditions.checkArgument(iterable.iterator().hasNext(), "Iterable cannot be empty.");
+
         String translate = colorAgent.translate(this.current);
         String text = parsePAPI(null, translate);
         String[] message = text.split("\n");
@@ -162,7 +171,10 @@ public class Message implements Deliverable<CommandSender> {
      * @param text The text of the message.
      * @return The message.
      */
-    public static Message of(@NotNull String... text) {
+    public static Message of(final String... text) {
+        Preconditions.checkNotNull(text, "Text cannot be null.");
+        Preconditions.checkArgument(text.length > 0, "Text cannot be empty.");
+
         return new Message(String.join("\n", text));
     }
 
@@ -172,7 +184,9 @@ public class Message implements Deliverable<CommandSender> {
      * @param text The text of the message.
      * @return The message.
      */
-    public static Message of(@NotNull String text) {
+    public static Message of(final String text) {
+        Preconditions.checkNotNull(text, "Text cannot be null.");
+
         return new Message(text);
     }
 
@@ -182,7 +196,10 @@ public class Message implements Deliverable<CommandSender> {
      * @param text The text of the message.
      * @return The message.
      */
-    public static Message of(@NotNull List<String> text) {
+    public static Message of(final List<String> text) {
+        Preconditions.checkNotNull(text, "Text cannot be null.");
+        Preconditions.checkArgument(text.size() > 0, "Text cannot be empty.");
+
         return new Message(String.join("\n", text));
     }
 
@@ -195,7 +212,9 @@ public class Message implements Deliverable<CommandSender> {
      * @apiNote The sender parameter can be null if you want to parse the message for the console.
      */
     @NotNull
-    private String parsePAPI(@Nullable CommandSender sender, @NotNull String message) {
+    private String parsePAPI(final CommandSender sender, final String message) {
+        Preconditions.checkNotNull(message, "Message cannot be null.");
+
         boolean enabled = Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI");
         if (!enabled || !parsePlaceholderAPI) return message;
 

--- a/src/main/java/games/negative/alumina/message/color/AluminaColorAgent.java
+++ b/src/main/java/games/negative/alumina/message/color/AluminaColorAgent.java
@@ -1,7 +1,7 @@
 package games.negative.alumina.message.color;
 
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.ChatColor;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,7 +28,9 @@ public class AluminaColorAgent implements ColorAgent {
     }
 
     @Override
-    public @NotNull String translate(@NotNull String input) {
+    public String translate(String input) {
+        Preconditions.checkNotNull(input, "input cannot be null!");
+
         Matcher matcher = PATTERN.matcher(input);
         while (matcher.find()) {
             String color = input.substring(matcher.start(), matcher.end());

--- a/src/main/java/games/negative/alumina/message/color/ColorAgent.java
+++ b/src/main/java/games/negative/alumina/message/color/ColorAgent.java
@@ -1,7 +1,5 @@
 package games.negative.alumina.message.color;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * This interface is used to translate color codes, and external plugins can implement this interface to use their own color codes.
  * If they do not like the way that alumina implements color codes.
@@ -13,6 +11,5 @@ public interface ColorAgent {
      * @param input The input string.
      * @return The translated string.
      */
-    @NotNull
-    String translate(@NotNull String input);
+    String translate(String input);
 }

--- a/src/main/java/games/negative/alumina/message/color/MinecraftColorAgent.java
+++ b/src/main/java/games/negative/alumina/message/color/MinecraftColorAgent.java
@@ -1,14 +1,13 @@
 package games.negative.alumina.message.color;
 
 import net.md_5.bungee.api.ChatColor;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Minecraft's default color agent.
  */
 public class MinecraftColorAgent implements ColorAgent {
     @Override
-    public @NotNull String translate(@NotNull String input) {
+    public String translate(String input) {
         return ChatColor.translateAlternateColorCodes('&', input);
     }
 }

--- a/src/main/java/games/negative/alumina/model/Deliverable.java
+++ b/src/main/java/games/negative/alumina/model/Deliverable.java
@@ -1,7 +1,5 @@
 package games.negative.alumina.model;
 
-import org.jetbrains.annotations.NotNull;
-
 /**
  * Represents a piece of content that can be sent to a receiver.
  * @param <T> The type of the receiver.
@@ -13,6 +11,6 @@ public interface Deliverable<T> {
      * Sends the content to the receiver.
      * @param receiver The receiver of the content.
      */
-    void send(@NotNull T receiver);
+    void send(final T receiver);
 
 }

--- a/src/main/java/games/negative/alumina/model/position/BlockRegion.java
+++ b/src/main/java/games/negative/alumina/model/position/BlockRegion.java
@@ -1,5 +1,6 @@
 package games.negative.alumina.model.position;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import games.negative.alumina.util.LocationUtil;
 import org.bukkit.Location;
@@ -24,7 +25,14 @@ import java.util.function.Predicate;
  * @param min The minimum block position.
  * @param max The maximum block position.
  */
-public record BlockRegion(@NotNull String name, @NotNull World world, @NotNull BlockPosition min, @NotNull BlockPosition max) implements ConfigurationSerializable {
+public record BlockRegion(String name, World world, BlockPosition min, BlockPosition max) implements ConfigurationSerializable {
+
+    public BlockRegion {
+        Preconditions.checkNotNull(name, "Name cannot be null.");
+        Preconditions.checkNotNull(world, "World cannot be null.");
+        Preconditions.checkNotNull(min, "Min cannot be null.");
+        Preconditions.checkNotNull(max, "Max cannot be null.");
+    }
 
     /**
      * Check if a location is inside the region.

--- a/src/main/java/games/negative/alumina/util/ColorUtil.java
+++ b/src/main/java/games/negative/alumina/util/ColorUtil.java
@@ -27,10 +27,9 @@
 
 package games.negative.alumina.util;
 
+import com.google.common.base.Preconditions;
 import net.md_5.bungee.api.ChatColor;
-import org.jetbrains.annotations.NotNull;
 
-import java.lang.ref.PhantomReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -52,7 +51,9 @@ public class ColorUtil {
      * @param input The string to translate.
      * @return The translated string.
      */
-    public static String translate(@NotNull String input) {
+    public static String translate(String input) {
+        Preconditions.checkNotNull(input, "Input cannot be null.");
+
         Matcher matcher = PATTERN.matcher(input);
         while (matcher.find()) {
             String color = input.substring(matcher.start(), matcher.end());

--- a/src/main/java/games/negative/alumina/util/FileLoader.java
+++ b/src/main/java/games/negative/alumina/util/FileLoader.java
@@ -3,7 +3,6 @@ package games.negative.alumina.util;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -19,7 +18,10 @@ public class FileLoader {
      * @param resource The name of the file to load.
      * @return The loaded file.
      */
-    public static File loadFile(@NotNull JavaPlugin plugin, @NotNull String resource) {
+    public static File loadFile(final JavaPlugin plugin, final String resource) {
+        Preconditions.checkNotNull(plugin, "Plugin cannot be null.");
+        Preconditions.checkNotNull(resource, "Resource cannot be null.");
+
         File folder = plugin.getDataFolder();
         if (!folder.exists()) folder.mkdir();
 

--- a/src/main/java/games/negative/alumina/util/InventoryUtil.java
+++ b/src/main/java/games/negative/alumina/util/InventoryUtil.java
@@ -1,13 +1,12 @@
 package games.negative.alumina.util;
 
-import lombok.SneakyThrows;
+import com.google.common.base.Preconditions;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.util.io.BukkitObjectInputStream;
 import org.bukkit.util.io.BukkitObjectOutputStream;
-import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
 
 import java.io.ByteArrayInputStream;
@@ -25,7 +24,9 @@ public class InventoryUtil {
      * @return A {@link String} array, the first element is the main content, the second element is the armor.
      * @throws IllegalStateException If the inventory cannot be converted.
      */
-    public String[] playerInventoryToBase64(@NotNull PlayerInventory playerInventory) throws IllegalStateException {
+    public String[] playerInventoryToBase64(final PlayerInventory playerInventory) throws IllegalStateException {
+        Preconditions.checkNotNull(playerInventory, "Player inventory cannot be null.");
+
         //get the main content part, this doesn't return the armor
         String content = inventoryToBase64(playerInventory);
         String armor = itemStackArrayToBase64(playerInventory.getArmorContents());
@@ -39,7 +40,9 @@ public class InventoryUtil {
      * @return The base64 string.
      * @throws IllegalStateException If the item stack array cannot be converted.
      */
-    public String itemStackArrayToBase64(@NotNull ItemStack[] items) throws IllegalStateException {
+    public String itemStackArrayToBase64(final ItemStack[] items) throws IllegalStateException {
+        Preconditions.checkNotNull(items, "Item stack array cannot be null.");
+
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
@@ -66,7 +69,9 @@ public class InventoryUtil {
      * @return The base64 string.
      * @throws IllegalStateException If the inventory cannot be converted.
      */
-    public String inventoryToBase64(@NotNull Inventory inventory) throws IllegalStateException {
+    public String inventoryToBase64(final Inventory inventory) throws IllegalStateException {
+        Preconditions.checkNotNull(inventory, "Inventory cannot be null.");
+
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
@@ -93,8 +98,8 @@ public class InventoryUtil {
      * @return The inventory.
      * @throws IllegalStateException If the base64 string cannot be converted.
      */
-    @SneakyThrows
-    public Inventory inventoryFromBase64(@NotNull String data) throws IllegalStateException {
+    public Inventory inventoryFromBase64(final String data) throws IllegalStateException, IOException {
+        Preconditions.checkNotNull(data, "Base64 string cannot be null.");
         try {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
@@ -109,6 +114,8 @@ public class InventoryUtil {
             return inventory;
         } catch (ClassNotFoundException e) {
             throw new IOException("Unable to decode class type.", e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -118,8 +125,9 @@ public class InventoryUtil {
      * @return The item stack array.
      * @throws IllegalStateException If the base64 string cannot be converted.
      */
-    @SneakyThrows
-    public ItemStack[] itemStackArrayFromBase64(@NotNull String data) throws IllegalStateException {
+    public ItemStack[] itemStackArrayFromBase64(final String data) throws IllegalStateException, IOException {
+        Preconditions.checkNotNull(data, "Base64 string cannot be null.");
+
         try {
             ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
             BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
@@ -134,6 +142,8 @@ public class InventoryUtil {
             return items;
         } catch (ClassNotFoundException e) {
             throw new IOException("Unable to decode class type.", e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/games/negative/alumina/util/ItemUpdater.java
+++ b/src/main/java/games/negative/alumina/util/ItemUpdater.java
@@ -1,8 +1,8 @@
 package games.negative.alumina.util;
 
+import com.google.common.base.Preconditions;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.function.Consumer;
 
@@ -17,7 +17,10 @@ public class ItemUpdater {
      * @param item Item to update
      * @param processor Processor to use
      */
-    public static void of(@NotNull ItemStack item, @NotNull Consumer<ItemMeta> processor) {
+    public static void of(final ItemStack item, final Consumer<ItemMeta> processor) {
+        Preconditions.checkNotNull(item, "item cannot be null!");
+        Preconditions.checkNotNull(processor, "processor cannot be null!");
+
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
 
@@ -32,7 +35,11 @@ public class ItemUpdater {
      * @param processor Processor to use
      * @param <T> Type of the ItemMeta
      */
-    public static <T extends ItemMeta> void of(@NotNull ItemStack item, @NotNull Class<T> type, @NotNull Consumer<T> processor) {
+    public static <T extends ItemMeta> void of(final ItemStack item, final Class<T> type, final Consumer<T> processor) {
+        Preconditions.checkNotNull(item, "item cannot be null!");
+        Preconditions.checkNotNull(type, "type cannot be null!");
+        Preconditions.checkNotNull(processor, "processor cannot be null!");
+
         ItemMeta meta = item.getItemMeta();
         if (meta == null) return;
 

--- a/src/main/java/games/negative/alumina/util/JsonUtil.java
+++ b/src/main/java/games/negative/alumina/util/JsonUtil.java
@@ -1,9 +1,8 @@
 package games.negative.alumina.util;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 
@@ -22,7 +21,10 @@ public class JsonUtil {
      * @param <T> The type of the object.
      * @throws IOException If the file could not be saved.
      */
-    public static <T> void save(@NotNull T instance, @NotNull File file, @Nullable Gson gson) throws IOException {
+    public static <T> void save(final T instance, final File file, Gson gson) throws IOException {
+        Preconditions.checkNotNull(instance, "Instance cannot be null!");
+        Preconditions.checkNotNull(file, "File cannot be null!");
+
         if (gson == null) gson = GSON;
 
         file.getParentFile().mkdirs();
@@ -43,7 +45,10 @@ public class JsonUtil {
      * @param <T> The type of the object.
      * @throws IOException If the file could not be saved.
      */
-    public static <T> void save(@NotNull T instance, @NotNull File file) throws IOException {
+    public static <T> void save(final T instance, final File file) throws IOException {
+        Preconditions.checkNotNull(instance, "Instance cannot be null!");
+        Preconditions.checkNotNull(file, "File cannot be null!");
+
         save(instance, file, null);
     }
 
@@ -57,8 +62,11 @@ public class JsonUtil {
      * @param <T> The type of the object.
      * @throws IOException If the file could not be loaded.
      */
-    @NotNull
-    public static <T> T loadOrCreate(@NotNull File file, @NotNull Class<T> clazz, @NotNull T clean, @Nullable Gson gson) throws IOException {
+    public static <T> T loadOrCreate(final File file, final Class<T> clazz, final T clean, final Gson gson) throws IOException {
+        Preconditions.checkNotNull(file, "File cannot be null!");
+        Preconditions.checkNotNull(clazz, "Class cannot be null!");
+        Preconditions.checkNotNull(clean, "Clean instance cannot be null!");
+
         if (!file.exists()) {
             save(clean, file, gson);
             return clean;
@@ -77,8 +85,11 @@ public class JsonUtil {
      * @param <T> The type of the object.
      * @throws IOException If the file could not be loaded.
      */
-    @NotNull
-    public static <T> T loadOrCreate(@NotNull File file, @NotNull Class<T> clazz, @NotNull T clean) throws IOException {
+    public static <T> T loadOrCreate(final File file, final Class<T> clazz, final T clean) throws IOException {
+        Preconditions.checkNotNull(file, "File cannot be null!");
+        Preconditions.checkNotNull(clazz, "Class cannot be null!");
+        Preconditions.checkNotNull(clean, "Clean instance cannot be null!");
+
         return loadOrCreate(file, clazz, clean, null);
     }
 
@@ -91,8 +102,10 @@ public class JsonUtil {
      * @param <T> The type of the object.
      * @throws IOException If the file could not be loaded.
      */
-    @NotNull
-    public static <T> T load(@NotNull File file, @NotNull Class<T> clazz, @Nullable Gson gson) throws IOException {
+    public static <T> T load(final File file, final Class<T> clazz, Gson gson) throws IOException {
+        Preconditions.checkNotNull(file, "File cannot be null!");
+        Preconditions.checkNotNull(clazz, "Class cannot be null!");
+
         if (gson == null) gson = GSON;
 
         file.getParentFile().mkdirs();
@@ -113,8 +126,10 @@ public class JsonUtil {
      * @param <T> The type of the object.
      * @throws IOException If the file could not be loaded.
      */
-    @NotNull
-    public static <T> T load(@NotNull File file, @NotNull Class<T> clazz) throws IOException {
+    public static <T> T load(final File file, final Class<T> clazz) throws IOException {
+        Preconditions.checkNotNull(file, "File cannot be null!");
+        Preconditions.checkNotNull(clazz, "Class cannot be null!");
+
         return load(file, clazz, null);
     }
 }

--- a/src/main/java/games/negative/alumina/util/LocationUtil.java
+++ b/src/main/java/games/negative/alumina/util/LocationUtil.java
@@ -1,19 +1,16 @@
 package games.negative.alumina.util;
 
 import com.google.common.base.Preconditions;
-import lombok.experimental.UtilityClass;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
 /**
- * A location utility to handle some location related tasks.
+ * A location utility to handle some location-related tasks.
  */
-@UtilityClass
 public class LocationUtil {
 
     /**
@@ -22,8 +19,9 @@ public class LocationUtil {
      * @param location The location to convert.
      * @return The yaml map.
      */
-    @NotNull
-    public Map<String, Object> toYaml(@NotNull Location location) {
+    public static Map<String, Object> toYaml(final Location location) {
+        Preconditions.checkNotNull(location, "Location cannot be null!");
+
         World world = location.getWorld();
         Preconditions.checkNotNull(world, "World cannot be null!");
 
@@ -43,8 +41,9 @@ public class LocationUtil {
      * @param section The section to convert.
      * @return The location.
      */
-    @NotNull
-    public Location fromYaml(@NotNull ConfigurationSection section) {
+    public static Location fromYaml(final ConfigurationSection section) {
+        Preconditions.checkNotNull(section, "Section cannot be null!");
+
         World world = Bukkit.getWorld(section.getString("world", "world"));
         Preconditions.checkNotNull(world, "World cannot be null!");
 
@@ -64,8 +63,9 @@ public class LocationUtil {
      * @param map The map to convert.
      * @return The location.
      */
-    @NotNull
-    public Location fromYaml(@NotNull Map<String, Object> map) {
+    public static Location fromYaml(final Map<String, Object> map) {
+        Preconditions.checkNotNull(map, "Map cannot be null!");
+
         World world = Bukkit.getWorld((String) map.get("world"));
         Preconditions.checkNotNull(world, "World cannot be null!");
 
@@ -87,7 +87,11 @@ public class LocationUtil {
      * @param max      The maximum location of the cuboid.
      * @return Whether the location is inside the cuboid.
      */
-    public boolean isInside(@NotNull Location location, @NotNull Location min, @NotNull Location max) {
+    public static boolean isInside(final Location location, final Location min, final Location max) {
+        Preconditions.checkNotNull(location, "'location' cannot be null!");
+        Preconditions.checkNotNull(min, "'min' cannot be null!");
+        Preconditions.checkNotNull(max, "'max' cannot be null!");
+
         World locationWorld = location.getWorld();
         World minWorld = min.getWorld();
         World maxWorld = max.getWorld();

--- a/src/main/java/games/negative/alumina/util/NBTEditor.java
+++ b/src/main/java/games/negative/alumina/util/NBTEditor.java
@@ -1,17 +1,15 @@
 package games.negative.alumina.util;
 
-import lombok.experimental.UtilityClass;
+import com.google.common.base.Preconditions;
 import org.bukkit.NamespacedKey;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataHolder;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * This is a class used to reduce boilerplate when working with persistent data.
  */
-@UtilityClass
 public class NBTEditor {
 
     /**
@@ -24,8 +22,11 @@ public class NBTEditor {
      * @param <T>    The type of the holder.
      * @return The value, or null if it does not exist.
      */
-    @Nullable
-    public <V, T extends PersistentDataHolder> V get(@NotNull T holder, @NotNull NamespacedKey key, @NotNull PersistentDataType<V, V> type) {
+    public static <V, T extends PersistentDataHolder> V get(final T holder, final NamespacedKey key, final PersistentDataType<V, V> type) {
+        Preconditions.checkNotNull(holder, "'holder' cannot be null!");
+        Preconditions.checkNotNull(key, "'key' cannot be null!");
+        Preconditions.checkNotNull(type, "'type' cannot be null!");
+
         PersistentDataContainer container = holder.getPersistentDataContainer();
         if (!container.has(key, type)) return null;
 
@@ -44,7 +45,12 @@ public class NBTEditor {
      * @return The value, or the default value if it does not exist.
      */
     @NotNull
-    public <V, T extends PersistentDataHolder> V getOrDefault(@NotNull T holder, @NotNull NamespacedKey key, @NotNull PersistentDataType<V, V> type, @NotNull V def) {
+    public static <V, T extends PersistentDataHolder> V getOrDefault(final T holder, final NamespacedKey key, final PersistentDataType<V, V> type, final V def) {
+        Preconditions.checkNotNull(holder, "'holder' cannot be null!");
+        Preconditions.checkNotNull(key, "'key' cannot be null!");
+        Preconditions.checkNotNull(type, "'type' cannot be null!");
+        Preconditions.checkNotNull(def, "'def' cannot be null!");
+
         V value = get(holder, key, type);
         return value == null ? def : value;
     }
@@ -56,7 +62,10 @@ public class NBTEditor {
      * @param key    The key to remove the value from.
      * @param <T>    The type of the holder.
      */
-    public <T extends PersistentDataHolder> void remove(@NotNull T holder, @NotNull NamespacedKey key) {
+    public static <T extends PersistentDataHolder> void remove(final T holder, final NamespacedKey key) {
+        Preconditions.checkNotNull(holder, "'holder' cannot be null!");
+        Preconditions.checkNotNull(key, "'key' cannot be null!");
+
         PersistentDataContainer container = holder.getPersistentDataContainer();
         container.remove(key);
     }
@@ -71,7 +80,12 @@ public class NBTEditor {
      * @param <V>    The type of the value.
      * @param <T>    The type of the holder.
      */
-    public <V, T extends PersistentDataHolder> void set(@NotNull T holder, @NotNull NamespacedKey key, @NotNull PersistentDataType<V, V> type, @NotNull V value) {
+    public static <V, T extends PersistentDataHolder> void set(final T holder, final NamespacedKey key, final PersistentDataType<V, V> type, final V value) {
+        Preconditions.checkNotNull(holder, "'holder' cannot be null!");
+        Preconditions.checkNotNull(key, "'key' cannot be null!");
+        Preconditions.checkNotNull(type, "'type' cannot be null!");
+        Preconditions.checkNotNull(value, "'value' cannot be null!");
+
         PersistentDataContainer container = holder.getPersistentDataContainer();
         container.set(key, type, value);
     }
@@ -86,7 +100,11 @@ public class NBTEditor {
      * @param <T>    The type of the holder.
      * @return If the holder has the value.
      */
-    public <V, T extends PersistentDataHolder> boolean has(@NotNull T holder, @NotNull NamespacedKey key, @NotNull PersistentDataType<V, V> type) {
+    public static <V, T extends PersistentDataHolder> boolean has(final T holder, final NamespacedKey key, final PersistentDataType<V, V> type) {
+        Preconditions.checkNotNull(holder, "'holder' cannot be null!");
+        Preconditions.checkNotNull(key, "'key' cannot be null!");
+        Preconditions.checkNotNull(type, "'type' cannot be null!");
+
         PersistentDataContainer container = holder.getPersistentDataContainer();
         return container.has(key, type);
     }
@@ -99,7 +117,10 @@ public class NBTEditor {
      * @param <T>    The type of the holder.
      * @return If the holder has the value.
      */
-    public <T extends PersistentDataHolder> boolean has(@NotNull T holder, @NotNull NamespacedKey key) {
+    public static <T extends PersistentDataHolder> boolean has(final T holder, final NamespacedKey key) {
+        Preconditions.checkNotNull(holder, "'holder' cannot be null!");
+        Preconditions.checkNotNull(key, "'key' cannot be null!");
+
         PersistentDataContainer container = holder.getPersistentDataContainer();
         return container.getKeys().contains(key);
     }

--- a/src/main/java/games/negative/alumina/util/NumberUtil.java
+++ b/src/main/java/games/negative/alumina/util/NumberUtil.java
@@ -27,8 +27,7 @@
 
 package games.negative.alumina.util;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import com.google.common.base.Preconditions;
 
 import java.text.DecimalFormat;
 
@@ -108,7 +107,9 @@ public class NumberUtil {
      * @param text Text to check
      * @return If the text is a {@link Integer}
      */
-    public static boolean isInteger(@NotNull String text) {
+    public static boolean isInteger(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         try {
             Integer.parseInt(text);
             return true;
@@ -124,8 +125,9 @@ public class NumberUtil {
      * @return {@link Integer} from the text
      * @throws NullPointerException If the text is not an {@link Integer}
      */
-    @Nullable
-    public static Integer getInteger(@NotNull String text) {
+    public static Integer getInteger(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         if (!isInteger(text)) return null;
 
         return Integer.parseInt(text);
@@ -137,7 +139,9 @@ public class NumberUtil {
      * @param text Text to check
      * @return If the text is a {@link Long}
      */
-    public static boolean isLong(@NotNull String text) {
+    public static boolean isLong(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         try {
             Long.parseLong(text);
             return true;
@@ -153,8 +157,9 @@ public class NumberUtil {
      * @return {@link Long} from the text
      * @throws NullPointerException If the text is not an {@link Long}
      */
-    @Nullable
-    public static Long getLong(@NotNull String text) {
+    public static Long getLong(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         if (!isLong(text)) return null;
 
         return Long.parseLong(text);
@@ -166,7 +171,9 @@ public class NumberUtil {
      * @param text Text to check
      * @return If the text is a {@link Double}
      */
-    public static boolean isDouble(@NotNull String text) {
+    public static boolean isDouble(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         try {
             Double.parseDouble(text);
             return true;
@@ -182,8 +189,9 @@ public class NumberUtil {
      * @return {@link Double} from the text
      * @throws NullPointerException If the text is not an {@link Double}
      */
-    @Nullable
-    public static Double getDouble(@NotNull String text) {
+    public static Double getDouble(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         if (!isDouble(text)) return null;
 
         return Double.parseDouble(text);
@@ -195,7 +203,9 @@ public class NumberUtil {
      * @param text Text to check
      * @return If the text is a {@link Float}
      */
-    public static boolean isFloat(@NotNull String text) {
+    public static boolean isFloat(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         try {
             Float.parseFloat(text);
             return true;
@@ -211,8 +221,9 @@ public class NumberUtil {
      * @return {@link Float} from the text
      * @throws NullPointerException If the text is not an {@link Float}
      */
-    @Nullable
-    public static Float getFloat(@NotNull String text) {
+    public static Float getFloat(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         if (!isFloat(text)) return null;
 
         return Float.parseFloat(text);
@@ -224,7 +235,9 @@ public class NumberUtil {
      * @param text Text to check
      * @return If the text is a {@link Short}
      */
-    public static boolean isShort(@NotNull String text) {
+    public static boolean isShort(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         try {
             Short.parseShort(text);
             return true;
@@ -240,8 +253,9 @@ public class NumberUtil {
      * @return {@link Short} from the text
      * @throws NullPointerException If the text is not an {@link Short}
      */
-    @Nullable
-    public static Short getShort(@NotNull String text) {
+    public static Short getShort(final String text) {
+        Preconditions.checkNotNull(text, "'text' cannot be null!");
+
         if (!isShort(text)) return null;
 
         return Short.parseShort(text);
@@ -254,7 +268,6 @@ public class NumberUtil {
      * @param number Number to convert
      * @return Fancy version of the number
      */
-    @NotNull
     public static String fancy(int number) {
         if (number % 100 >= 11 && number % 100 <= 13) {
             return decimalFormat(number) + "th";
@@ -275,7 +288,6 @@ public class NumberUtil {
      * @param number Number to convert
      * @return Fancy version of the number
      */
-    @NotNull
     public static String fancy(long number) {
         if (number % 100 >= 11 && number % 100 <= 13) {
             return decimalFormat(number) + "th";
@@ -296,7 +308,6 @@ public class NumberUtil {
      * @param number Number to convert
      * @return Fancy version of the number
      */
-    @NotNull
     public static String fancy(double number) {
         if (number % 100 >= 11 && number % 100 <= 13) {
             return decimalFormat(number) + "th";
@@ -317,7 +328,6 @@ public class NumberUtil {
      * @param number Number to convert
      * @return Fancy version of the number
      */
-    @NotNull
     public static String fancy(float number) {
         if (number % 100 >= 11 && number % 100 <= 13) {
             return number + "th";
@@ -338,7 +348,6 @@ public class NumberUtil {
      * @param number Number to convert
      * @return Fancy version of the number
      */
-    @NotNull
     public static String fancy(short number) {
         if (number % 100 >= 11 && number % 100 <= 13) {
             return decimalFormat(number) + "th";
@@ -359,7 +368,6 @@ public class NumberUtil {
      * @param number Number to convert
      * @return Fancy version of the number
      */
-    @NotNull
     public static String fancy(byte number) {
         if (number % 100 >= 11 && number % 100 <= 13) {
             return decimalFormat(number) + "th";
@@ -378,7 +386,6 @@ public class NumberUtil {
      * @param number Number to condense
      * @return Condensed number
      */
-    @NotNull
     public static String condense(int number) {
         if (number < 1000) return String.valueOf(number); // Return the number itself if less than 1000.
 
@@ -392,7 +399,6 @@ public class NumberUtil {
      * @param number Number to condense
      * @return Condensed number
      */
-    @NotNull
     public static String condense(double number) {
         if (number < 1000) return String.valueOf(number); // Return the number itself if less than 1000.
 
@@ -406,7 +412,6 @@ public class NumberUtil {
      * @param number Number to condense
      * @return Condensed number
      */
-    @NotNull
     public static String condense(long number) {
         if (number < 1000) return String.valueOf(number); // Return the number itself if less than 1000.
 

--- a/src/main/java/games/negative/alumina/util/PlayerUtil.java
+++ b/src/main/java/games/negative/alumina/util/PlayerUtil.java
@@ -1,5 +1,6 @@
 package games.negative.alumina.util;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import org.bukkit.GameMode;
 import org.bukkit.attribute.Attribute;
@@ -8,7 +9,6 @@ import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
 import java.util.List;
@@ -22,7 +22,9 @@ public class PlayerUtil {
      * Reset the player to default properties.
      * @param player The player to reset.
      */
-    public static void reset(@NotNull Player player) {
+    public static void reset(final Player player) {
+        Preconditions.checkNotNull(player, "'player' cannot be null!");
+
         for (PotionEffect effect : player.getActivePotionEffects())
             player.removePotionEffect(effect.getType());
 
@@ -51,7 +53,9 @@ public class PlayerUtil {
      * Reset the player's health.
      * @param player The player to reset.
      */
-    private static void resetHealth(@NotNull Player player) {
+    private static void resetHealth(final Player player) {
+        Preconditions.checkNotNull(player, "'player' cannot be null!");
+
         AttributeInstance attribute = player.getAttribute(Attribute.GENERIC_MAX_HEALTH);
         if (attribute == null) return;
 

--- a/src/main/java/games/negative/alumina/util/TimeUtil.java
+++ b/src/main/java/games/negative/alumina/util/TimeUtil.java
@@ -83,7 +83,10 @@ public class TimeUtil {
      * @param input Input string
      * @return Formatted time
      */
-    public static long fromString(@NotNull String input) {
+    public static long fromString(final String input) {
+        Preconditions.checkNotNull(input, "'input' cannot be null!");
+        Preconditions.checkArgument(!input.isEmpty(), "'input' cannot be empty!");
+
         StringBuilder builder = new StringBuilder();
         int seconds = 0;
         int minutes = 0;
@@ -138,11 +141,13 @@ public class TimeUtil {
     private static class TimeFormatter {
         private final LinkedList<String> entries = new LinkedList<>();
 
-        public TimeFormatter(@NotNull String... entries) {
+        public TimeFormatter(final String... entries) {
+            Preconditions.checkNotNull(entries, "'entries' cannot be null!");
+
             this.entries.addAll(Arrays.asList(entries));
         }
 
-        @NotNull
+
         public String toString() {
             StringBuilder builder = new StringBuilder();
             for (String entry : entries) {


### PR DESCRIPTION
Purposing this change because some people may or may not have or use Jetbrains Annotations and Lombok in their projects, and I think the external library annotation use should be as minimal as possible, so I have purged the use of annotations such as `@NotNull`, `@Nullable`, `@SneakyThrows`, etc. I have replaced the use of annotations with Google's Guava's `Preconditions` checker class.