### PR TITLE
Smart-Tab-Complete Intelligence Upgrade

### DIFF
--- a/src/main/java/games/negative/alumina/command/Command.java
+++ b/src/main/java/games/negative/alumina/command/Command.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import games.negative.alumina.message.Message;
+import games.negative.alumina.util.MathUtil;
 import lombok.Getter;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -281,6 +282,34 @@ public abstract class Command extends org.bukkit.command.Command {
 
             List<String> matched = match.stream().filter(entry -> entry.toLowerCase().contains(current)).toList();
             result.addAll(matched);
+        }
+
+        if (!result.isEmpty()) return result;
+
+        for (int i = args.length - 1; i >= 0; i--) {
+            if (i == placement) continue;
+
+            String arg = args[i];
+            if (arg.isEmpty()) continue;
+
+            Command cmd = subMap.get(i).stream()
+                    .filter(command -> command.getName().equalsIgnoreCase(arg) || command.getAliases().contains(arg.toLowerCase()) || (command.subAliases != null && command.subAliases.contains(arg.toLowerCase())))
+                    .findFirst().orElse(null);
+
+            if (cmd == null || hasInvalidPermissions(sender, false)) continue;
+
+            List<String> completion = cmd.onTabComplete(context);
+            if (completion != null && !completion.isEmpty()) {
+                result.addAll(completion);
+                continue;
+            }
+
+            int depth = (MathUtil.absDiff(i, placement) - 1);
+            try {
+                String param = cmd.getParams().get(depth);
+                result.add("[<" + param + ">]");
+            } catch (Exception ignored) {
+            }
         }
 
         return result;

--- a/src/main/java/games/negative/alumina/command/TabContext.java
+++ b/src/main/java/games/negative/alumina/command/TabContext.java
@@ -66,4 +66,11 @@ public record TabContext(CommandSender sender, String[] args) {
         return argument(args.length - 1).orElseThrow(() -> new IllegalStateException("No current argument"));
     }
 
+    /**
+     * Returns the index of the current argument.
+     * @return the index of the current argument.
+     */
+    public int index() {
+        return args.length - 1;
+    }
 }


### PR DESCRIPTION
Upgraded the intelligence of the **Smart Tab Complete** system to allow for detecting required command parameters and also allowing for the `onTabComplete` function to override the default `[<%parameter%>]` text that gets sent to the client if wanting custom outputs for parameter tab-complete options.

For example, instead of having `[<player>]` be returned as a tab complete option when doing `/msg` , you can return a list of all online players!